### PR TITLE
add properties config example.

### DIFF
--- a/examples/propertyConf/.gitignore
+++ b/examples/propertyConf/.gitignore
@@ -1,0 +1,5 @@
+target/
+.settings/
+.project
+.classpath
+.factorypath

--- a/examples/propertyConf/pom.xml
+++ b/examples/propertyConf/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.github.dubasdey</groupId>
+	<artifactId>log4j2-jsonevent-layout-example-property-conf</artifactId>
+	<version>0.0.1</version>
+	<name>log4j2-jsonevent-layout</name>
+	<description>Log4j2 JSON Event layout properties config example</description>
+	<url>https://github.com/dubasdey/log4j2-jsonevent-layout</url>
+	
+	<licenses>
+	    <license>
+	        <name>GNU LGPL v3</name>
+	        <url>https://www.gnu.org/licenses/lgpl-3.0.en.html</url>
+	        <distribution>repo</distribution>
+	    </license>
+	</licenses>
+	
+	<scm>
+    	<url>https://github.com/dubasdey/log4j2-jsonevent-layout</url>
+    	<connection>scm:git:git://github.com/dubasdey/log4j2-jsonevent-layout.git</connection>
+    	<developerConnection>scm:git:git@github.com:dubasdey/log4j2-jsonevent-layout.git</developerConnection>
+	</scm>
+
+	<properties>
+		<java.version>8</java.version>
+		<maven.compiler.source>8</maven.compiler.source>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<distributionManagement>
+	    <snapshotRepository>
+	        <id>ossrh</id>
+	        <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+	    </snapshotRepository>
+ 		<repository>
+      		<id>ossrh</id>
+      		<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    	</repository>	    
+	</distributionManagement>
+	
+	<developers>
+	    <developer>
+	        <id>erodriguez</id>
+	        <name>Eduardo Rodríguez</name>
+	        <email>eduardo@rodriguezcarro.es</email>
+	    </developer>
+	</developers>
+	
+	<dependencies>
+		
+	    <dependency>
+    		<groupId>org.apache.logging.log4j</groupId>
+    		<artifactId>log4j-core</artifactId>
+    		<version>2.17.1</version>
+	    </dependency>
+
+	    <dependency>
+			<groupId>com.github.dubasdey</groupId>
+			<artifactId>log4j2-jsonevent-layout</artifactId>
+			<version>0.0.7</version>
+	    </dependency>
+
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.3.2</version>
+				<configuration>
+					<encoding>utf-8</encoding>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/examples/propertyConf/src/main/java/org/erc/log4j2/layout/examples/basic/Main.java
+++ b/examples/propertyConf/src/main/java/org/erc/log4j2/layout/examples/basic/Main.java
@@ -1,0 +1,14 @@
+package org.erc.log4j2.layout.examples.basic;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class Main {
+    
+	private static final Logger logger = LogManager.getLogger(Main.class);
+	
+    public static void main(String[] args){
+    	logger.info("Debug line");
+    }
+}

--- a/examples/propertyConf/src/main/resources/log4j2.properties
+++ b/examples/propertyConf/src/main/resources/log4j2.properties
@@ -1,0 +1,12 @@
+rootLogger.level = DEBUG
+rootLogger.appenderRef.console.ref = STDOUT
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.target=SYSTEM_OUT
+appender.console.layout.type = JSONLog4j2Layout
+appender.console.layout.singleLine = true
+appender.console.layout.locationInfo = true
+appender.console.layout.xxx.type = UserField
+appender.console.layout.xxx.key = jobId
+appender.console.layout.xxx.value = 111


### PR DESCRIPTION
Due to the lack of introduce for properties configuration, I encountered several usage issues when implementing the properties configuration, particularly using UserField. This has taken up a considerable amount of time, and I believe others may meet the same problems (some distributed computing framework, such as Apache Flink, by default using  properties configurations upon the startup of job). Therefore, I have added an example of properties to help everyone quickly use the layout via properties configuration.